### PR TITLE
[DRAFT] support for configurable settings for security-secrets-setup

### DIFF
--- a/cmd/security-secrets-setup/res/configuration.toml
+++ b/cmd/security-secrets-setup/res/configuration.toml
@@ -1,6 +1,12 @@
 [Writable]
-LogLevel = 'DEBUG'
+LogLevel = 'INFO'
 
 [Logging]
 EnableRemote = false
 File = './logs/security-secrets-setup.log'
+
+[SecretsSetup]
+WorkDir = "/run/edgex/secrets-setup"
+DeployDir = "/run/edgex/secrets"
+CacheDir = "/etc/edgex/pki"
+CertConfigDir = "./res"

--- a/internal/security/setup/config.go
+++ b/internal/security/setup/config.go
@@ -17,10 +17,18 @@ package setup
 import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
 
 type ConfigurationStruct struct {
-	Writable WritableInfo
-	Logging  config.LoggingInfo
+	Writable     WritableInfo
+	Logging      config.LoggingInfo
+	SecretsSetup SecretsSetupInfo
 }
 
 type WritableInfo struct {
 	LogLevel string
+}
+
+type SecretsSetupInfo struct {
+	WorkDir       string
+	DeployDir     string
+	CacheDir      string
+	CertConfigDir string
 }

--- a/internal/security/setup/option/constant.go
+++ b/internal/security/setup/option/constant.go
@@ -18,7 +18,6 @@ package option
 
 import (
 	"errors"
-	"path/filepath"
 )
 
 const (
@@ -27,14 +26,15 @@ const (
 
 	pkiSetupVaultJSON             = "pkisetup-vault.json"
 	pkiSetupKongJSON              = "pkisetup-kong.json"
+	pkiInitScratchDir             = "scratch"
+	pkiInitGeneratedDir           = "generated"
 	resourceDirName               = "res"
 	configTomlFile                = "configuration.toml"
 	envXdgRuntimeDir              = "XDG_RUNTIME_DIR"
-	defaultXdgRuntimeDir          = "/tmp"
-	pkiInitBaseDir                = "/edgex/security-secrets-setup"
-	envPkiCache                   = "PKI_CACHE"
+	defaultWorkDir                = "/tmp"
+	pkiInitBaseDir                = "edgex/security-secrets-setup"
 	defaultPkiCacheDir            = "/etc/edgex/pki"
-	tmpfsRunDir                   = "/run"
+	defaultPkiDeployDir           = "/run/edgex/secrets"
 	tlsSecretFileName             = "server.key"
 	tlsCertFileName               = "server.crt"
 	caCertFileName                = "ca.pem"
@@ -47,8 +47,5 @@ const (
 )
 
 var (
-	pkiInitScratchDir      = filepath.Join(pkiInitBaseDir, "scratch")
-	pkiInitGeneratedDir    = filepath.Join(pkiInitBaseDir, "generated")
-	pkiInitDeployDir       = filepath.Join(tmpfsRunDir, "edgex", "secrets")
 	errCacheNotChangeAfter = errors.New("PKI cache cannot be changed after it was cached previously")
 )

--- a/internal/security/setup/option/import.go
+++ b/internal/security/setup/option/import.go
@@ -45,8 +45,11 @@ func isImportNoOp(pkiInitOption *PkiInitOption) bool {
 }
 
 func importPkis() (statusCode exitCode, err error) {
-	pkiCacheDir := getPkiCacheDirEnv()
-	setup.LoggingClient.Info(fmt.Sprintf("importing from PKI_CACHE: %s", pkiCacheDir))
+	pkiCacheDir, err := getCacheDir()
+	if err != nil {
+		return exitWithError, err
+	}
+	setup.LoggingClient.Info(fmt.Sprintf("importing from PKI cache dir: %s", pkiCacheDir))
 
 	dirEmpty, err := isDirEmpty(pkiCacheDir)
 
@@ -56,7 +59,11 @@ func importPkis() (statusCode exitCode, err error) {
 
 	if !dirEmpty {
 		// copy stuff into dest dir from pkiCache
-		err = deploy(pkiCacheDir, pkiInitDeployDir)
+		deployDir, err := getDeployDir()
+		if err != nil {
+			return exitWithError, err
+		}
+		err = deploy(pkiCacheDir, deployDir)
 		if err != nil {
 			statusCode = exitWithError
 		}

--- a/internal/security/setup/option/optionHelpers_test.go
+++ b/internal/security/setup/option/optionHelpers_test.go
@@ -1,0 +1,150 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package option
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWorkDir(t *testing.T) {
+	// sets up configuration for SecretsSetupInfo
+	tearDown := setupGenerateTest(t)
+	defer tearDown()
+
+	// test WorkDir that's configured by toml
+	runTimeDir, err := getWorkDir()
+	if err != nil {
+		t.Errorf("Error getting workdir, %v", err)
+	}
+	expectedWorkDir, err := filepath.Abs("./workingtest")
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, expectedWorkDir, runTimeDir)
+
+	// test default WorkDir
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			WorkDir: "",
+		},
+	}
+	runTimeDir, err = getWorkDir()
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(defaultWorkDir, pkiInitBaseDir), runTimeDir)
+
+	// test env variable
+	os.Setenv(envXdgRuntimeDir, "/run")
+	runTimeDir, err = getWorkDir()
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join("/run", pkiInitBaseDir), runTimeDir)
+}
+
+func TestGetCertConfigDir(t *testing.T) {
+	// sets up configuration data for SecretsSetupInfo
+	tearDown := setupGenerateTest(t)
+	defer tearDown()
+
+	// test CertConfigDir that's configured by toml
+	certConfigDir, err := getCertConfigDir()
+	assert.Nil(t, err)
+	assert.Equal(t, "./res", certConfigDir)
+
+	// certificate config dir not configured in toml
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			CertConfigDir: "",
+		},
+	}
+	certConfigDir, err = getCertConfigDir()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", certConfigDir)
+
+	// certificate config dir is configured but does not exist
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			CertConfigDir: "./fakePath",
+		},
+	}
+	_, err = getCertConfigDir()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestGetCacheDir(t *testing.T) {
+	// sets up configuration data for SecretsSetupInfo
+	tearDown := setupCacheTest(t)
+	defer tearDown()
+
+	// test CacheDir that's configured by toml
+	cacheDir, err := getCacheDir()
+	assert.Nil(t, err)
+	assert.Equal(t, "./cachetest", cacheDir)
+
+	// test default cacheDir
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			CacheDir: "",
+		},
+	}
+	cacheDir, _ = getCacheDir()
+	assert.Equal(t, defaultPkiCacheDir, cacheDir)
+
+	// cache directory is configured but does not exist
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			CacheDir: "./fakePath",
+		},
+	}
+	_, err = getCacheDir()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestGetDeployDir(t *testing.T) {
+	tearDown := setupImportTest(t)
+	defer tearDown()
+
+	// test DeployDir that's configured by toml
+	deployDir, err := getDeployDir()
+	assert.Nil(t, err)
+	assert.Equal(t, "./deploytest", deployDir)
+
+	// test default DeployDir
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			DeployDir: "",
+		},
+	}
+	deployDir, err = getDeployDir()
+	assert.Nil(t, err)
+	assert.Equal(t, defaultPkiDeployDir, deployDir)
+
+	// deploy directory is configured but does not exist
+	setup.Configuration = &setup.ConfigurationStruct{
+		SecretsSetup: setup.SecretsSetupInfo{
+			DeployDir: "./fakepath",
+		},
+	}
+	_, err = getDeployDir()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}

--- a/internal/security/setup/option/testdata/res/configuration.toml
+++ b/internal/security/setup/option/testdata/res/configuration.toml
@@ -4,3 +4,9 @@ LogLevel = 'DEBUG'
 [Logging]
 EnableRemote = false
 File = './logs/security-secrets-setup.log'
+
+[SecretsSetup]
+WorkDir = "./workingtest"
+DeployDir = "./deploytest"
+CacheDir = "./cachetest"
+CertConfigDir = "./res"


### PR DESCRIPTION
user can specify paths for WorkDir, CacheDir, DeployDir and
CertConfigDir in the configuration.toml
CertConfigDir specifies the directory for certificate configuration json
files
setting specified in environment variables override the configurable
settings

Signed-off-by: Enobong Udoko <enobong.n.udoko@intel.com>